### PR TITLE
fixed user property types mapping

### DIFF
--- a/plone/app/users/schemaeditor.py
+++ b/plone/app/users/schemaeditor.py
@@ -47,7 +47,7 @@ SPLITTER = '_//_'
 field_type_mapping = {
     "ASCIILine": 'text',
     "TextLine": 'text',
-    "Text": 'lines',
+    "Text": 'text',
     "Int": 'int',
     "Float": 'float',
     "Bool": 'boolean',


### PR DESCRIPTION
The bug report is at Plone Trac: [#13708: Invalid property types in plip13350-edit-member-schema-ttw](https://dev.plone.org/ticket/13708)
