### PR TITLE
adjust form/nav markup for Plone 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ CHANGES
 2.2 (unreleased)
 ----------------
 
+- Adjust navigation markup for Plone 5.
+  [davisagli]
+
 - Use email_from_address from registry (Plone 5) in tests.
   [khink]
 

--- a/plone/app/users/browser/account-configlet.pt
+++ b/plone/app/users/browser/account-configlet.pt
@@ -6,41 +6,9 @@
       metal:use-macro="here/prefs_main_template/macros/master"
       i18n:domain="plone">
 
-<body>
-
 <div metal:fill-slot="prefs_configlet_content">
 
-    <div id="edit-bar"
-         tal:define="view_name view/__name__;
-                     userquery python:view.makeQuery()">
-        <ul class="contentViews" id="content-views">
-          <li tal:define="selected python:view_name=='user-information'"
-              tal:attributes="class python:selected and 'selected' or 'plain'">
-            <a href=""
-               tal:attributes="href string:$portal_url/@@user-information${userquery}"
-               i18n:translate="title_personal_information_form">Personal Information</a>
-          </li>
-          <li tal:define="selected python:view_name=='user-preferences'"
-              tal:attributes="class python:selected and 'selected' or 'plain'">
-            <a href=""
-               tal:attributes="href string:$portal_url/@@user-preferences${userquery}"
-               i18n:translate="">Personal Preferences</a>
-          </li>
-
-          <li>
-            <a href=""
-               tal:attributes="href string:$portal_url/@@usergroup-usermembership${userquery}"
-               i18n:translate="label_group_memberships">Group Memberships</a>
-          </li>
-        </ul>
-        <div class="contentActions">&nbsp;</div>
-    </div>
-
-    <article id="content">
-
-    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-      Portal status message
-    </div>
+  <article id="content">
 
     <a
        href=""
@@ -52,13 +20,32 @@
 
     <h1 class="documentFirstHeading" tal:content="view/label | nothing" />
 
-    <div id="content-core">
-      <metal:block use-macro="context/@@ploneform-macros/titlelessform">
-      </metal:block>
+    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      Portal status message
     </div>
 
-    </article>
+    <div id="content-core">
+      <div class="autotabs">
+        <nav class="autotoc-nav"
+             tal:define="view_name view/__name__;
+                         userquery python:view.makeQuery()">
+          <a href="${portal_url}/@@user-information${userquery}"
+             tal:define="selected python:view_name=='user-information'"
+             tal:attributes="class python:'autotoc-level-1' + (' active' if selected else '')"
+             i18n:translate="title_personal_information_form">Personal Information</a>
+          <a href="${portal_url}/@@user-preferences${userquery}"
+             tal:define="selected python:view_name=='user-preferences'"
+             tal:attributes="class python:'autotoc-level-1' + (' active' if selected else '')"
+             i18n:translate="">Personal Preferences</a>
+          <a href="${portal_url}/@@usergroup-usermembership${userquery}"
+             i18n:translate="label_group_memberships">Group Memberships</a>
+        </nav>
+        <metal:b use-macro="context/@@ploneform-macros/titlelessform" />
+      </div>
+    </div>
+
+  </article>
 
 </div>
-</body>
+
 </html>

--- a/plone/app/users/browser/account-panel.pt
+++ b/plone/app/users/browser/account-panel.pt
@@ -5,46 +5,25 @@
       i18n:domain="plone"
       metal:use-macro="context/main_template/macros/master">
 
-    <metal:block fill-slot="content">
+  <metal:b fill-slot="content-title">
+    <h1 class="documentFirstHeading">${view/label}</h1>
+  </metal:b>
 
-        <div tal:define="view_actions view/prepareObjectTabs;"
-             id="edit-bar">
-        <h5 class="hiddenStructure"
-            tal:condition="view_actions"
-            i18n:translate="heading_views">Views</h5>
+  <metal:b fill-slot="content-core">
+    <div class="autotabs">
+      <nav class="autotoc-nav"
+           tal:define="view_actions view/prepareObjectTabs;">
+        <tal:views repeat="action view_actions">
+          <a id="contentview-${action/id}"
+             href="${action/url}"
+             tal:define="selected action/selected|nothing;"
+             tal:attributes="class python:'autotoc-level-1' + (' active' if selected else '')"
+             i18n:translate="">${action/title}</a>
+        </tal:views>
+      </nav>
 
-        <ul class="contentViews"
-            id="content-views"
-            i18n:domain="plone">
-
-            <tal:views repeat="action view_actions">
-              <li tal:define="selected action/selected|nothing;"
-                  tal:attributes="id string:contentview-${action/id};
-                                  class python:selected and 'selected' or 'plain'">
-                <a href=""
-                   tal:content="action/title"
-                   tal:attributes="href action/url;"
-                   i18n:translate="">
-                View name
-                </a>
-              </li>
-            </tal:views>
-
-        </ul>
-        </div>
-
-        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-            Portal status message
-        </div>
-
-        <article id="content">
-            <h1 class="documentFirstHeading" tal:content="view/label | nothing" />
-            <div id="content-core">
-                <metal:block use-macro="context/@@ploneform-macros/titlelessform">
-                </metal:block>
-            </div>
-        </article>
-
-    </metal:block>
+      <metal:b use-macro="context/@@ploneform-macros/titlelessform" />
+    </div>
+  </metal:b>
 
 </html>

--- a/plone/app/users/browser/account.py
+++ b/plone/app/users/browser/account.py
@@ -16,6 +16,7 @@ from plone.protect import CheckAuthenticator
 from plone.registry.interfaces import IRegistry
 from z3c.form import button
 from z3c.form import form
+from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.event import notify
@@ -91,6 +92,17 @@ class AccountPanelForm(AutoExtensibleForm, form.Form):
     hidden_widgets = []
     successMessage = _("Changes saved.")
     noChangesMessage = _("No changes made.")
+
+    @lazy_property
+    def member(self):
+        mtool = getToolByName(self.context, 'portal_membership')
+        if self.request.get('userid'):
+            return mtool.getMemberById(self.request.get('userid'))
+        return mtool.getAuthenticatedMember()
+
+    @property
+    def label(self):
+        return self.member.getProperty('fullname') or self.member.getUserName()
 
     def _differentEmail(self, email):
         """Check if the submitted form email address differs from the existing

--- a/plone/app/users/browser/memberregistration.pt
+++ b/plone/app/users/browser/memberregistration.pt
@@ -10,48 +10,34 @@
 
 <metal:main fill-slot="prefs_configlet_content">
 
-      <div id="edit-bar">
-          <ul class="contentViews" id="content-views">
-            <li>
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@usergroup-userprefs"
-                 i18n:translate="label_users">Users</a>
-            </li>
-            <li>
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                 i18n:translate="label_groups">Groups</a>
-            </li>
-            <li>
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@usergroup-controlpanel"
-                 i18n:translate="label_usergroup_settings">Settings</a>
-            </li>
-            <li class="selected">
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@member-registration"
-                 i18n:translate="label_member_registration">Member Registration</a>
-            </li>
-          </ul>
-          <div class="contentActions">
-            &nbsp;
-          </div>
+  <article id="content">
+    <h1 class="documentFirstHeading"
+        i18n:translate="heading_usergroup_settings">User/Groups Settings</h1>
+
+    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      Portal status message
+    </div>
+
+    <div class="autotabs">
+      <div class="autotoc-nav">
+        <a class="autotoc-level-1"
+           href="${portal_url}/@@usergroup-userprefs"
+           i18n:translate="label_users">Users</a>
+        <a class="autotoc-level-1"
+           href="${portal_url}/@@usergroup-groupprefs"
+           i18n:translate="label_groups">Groups</a>
+        <a class="autotoc-level-1"
+           href="${portal_url}/@@usergroup-controlpanel"
+           i18n:translate="label_usergroup_settings">Settings</a>
+        <a class="autotoc-level-1 active"
+           href="${portal_url}/@@member-registration"
+           i18n:translate="label_member_registration">Member Registration</a>
       </div>
 
-      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-        Portal status message
-      </div>
+      <metal:b use-macro="context/@@ploneform-macros/titlelessform" />
+    </div>
+  </article>
 
-      <article id="content">
-
-          <h1 class="documentFirstHeading"
-              i18n:translate="heading_usergroup_settings">User/Groups Settings</h1>
-
-          <div id="content-core">
-                <metal:block use-macro="context/@@ploneform-macros/titlelessform">
-                </metal:block>
-          </div>
-      </article>
 </metal:main>
 </body>
 </html>

--- a/plone/app/users/browser/passwordpanel.py
+++ b/plone/app/users/browser/passwordpanel.py
@@ -56,7 +56,6 @@ class PasswordPanelAdapter(object):
 class PasswordPanel(AccountPanelForm):
     """Implementation of password reset form that uses z3c.form."""
 
-    label = _(u'listingheader_reset_password', default=u'Reset Password')
     description = _(u"Change Password")
     form_name = _(u'legend_password_details', default=u'Password Details')
     schema = IPasswordSchema

--- a/plone/app/users/browser/personalpreferences.py
+++ b/plone/app/users/browser/personalpreferences.py
@@ -96,7 +96,6 @@ class PersonalPreferencesPanelAdapter(AccountPanelSchemaAdapter):
 class PersonalPreferencesPanel(AccountPanelForm):
     """Implementation of personalize form that uses z3c.form."""
 
-    label = _(u"heading_my_preferences", default=u"Personal Preferences")
     form_name = _(u'legend_personal_details', u'Personal Details')
     schema = IPersonalPreferences
 

--- a/plone/app/users/browser/userdatapanel.py
+++ b/plone/app/users/browser/userdatapanel.py
@@ -63,8 +63,6 @@ class UserDataPanelAdapter(AccountPanelSchemaAdapter):
 
 class UserDataPanel(AccountPanelForm):
 
-    label = _(u'title_personal_information_form',
-              default=u'Personal Information')
     form_name = _(u'User Data Form')
     schema = IUserDataSchema
     enableCSRFProtection = True


### PR DESCRIPTION
This shows the nav for the various personal forms (info, prefs, password) as tabs in the content area rather than hijacking the edit bar.