### PR TITLE
Plip 10359 - Security Control Panel migration

### DIFF
--- a/plone/app/users/tests/duplicate_email.rst
+++ b/plone/app/users/tests/duplicate_email.rst
@@ -32,7 +32,7 @@ Login as user two:
     >>> browser.open('http://nohost/plone/')
     >>> browser.getLink('Log in').click()
 
-    >>> browser.getControl('Login Name').value = 'usertwo@example.com'
+    >>> browser.getControl('E-mail').value = 'usertwo@example.com'
     >>> browser.getControl('Password').value = 'secret'
     >>> browser.getControl('Log in').click()
     >>> 'Login failed' in browser.contents

--- a/plone/app/users/tests/email_login.rst
+++ b/plone/app/users/tests/email_login.rst
@@ -67,10 +67,9 @@ Fill out the form, using an odd email address that should not give problems.
     >>> 'Failed to create your account' in browser.contents
     False
 
-    We can now login.
-    >>> browser.getLink('Log in').click()
-    >>> browser.getControl('Login Name').value = 'bob-jones+test@example.com'
-    >>> browser.getControl('Password').value = 'secret'
+    We can login immediately.
+    >>> 'Click the button to log in immediately.' in browser.contents
+    True
     >>> browser.getControl('Log in').click()
     >>> 'You are now logged in' in browser.contents
     True
@@ -81,9 +80,10 @@ Fill out the form, using an odd email address that should not give problems.
     True
     >>> browser.getLink(url='http://nohost/plone/logout').click()
 
-    We login as manager.
+    We login as manager. The login form now has a different label for
+    the login name.
     >>> browser.open('http://nohost/plone/login_form')
-    >>> browser.getControl('Login Name').value = SITE_OWNER_NAME
+    >>> browser.getControl('E-mail').value = SITE_OWNER_NAME
     >>> browser.getControl('Password').value = SITE_OWNER_PASSWORD
     >>> browser.getControl('Log in').click()
 

--- a/plone/app/users/tests/flexible_user_registration.rst
+++ b/plone/app/users/tests/flexible_user_registration.rst
@@ -147,6 +147,8 @@ Check render register form in 'Use Email As Login' mode.
     >>> browser.getControl('Password').value = 'testpassword'
     >>> browser.getControl('Confirm password').value = 'testpassword'
     >>> browser.getControl('Register').click()
+    >>> browser.contents
+    '...Welcome!...You have been registered...'
 
 Revert email mode.
 


### PR DESCRIPTION
Fix doctests, security settings are now properly read from the registry. This reverts some of the changes done in fd8a29812598df320637a03588cf0c7599d2a9e7 . See also https://github.com/plone/plone.app.users/pull/22 .

This is part of work on the security control panel migration https://github.com/plone/Products.CMFPlone/issues/216 and should be merged along with https://github.com/plone/Products.CMFPlone/pull/362