### PR TITLE
Provide a new schema adapter only when the TTW schema is changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ CHANGES
   warnings.
   [vincentfretin]
 
+- Provide a new schema adapter only when the TTW schema is changed
+  [ebrehault]
+
 
 2.3 (2015-07-18)
 ----------------

--- a/plone/app/users/browser/__init__.py
+++ b/plone/app/users/browser/__init__.py
@@ -1,0 +1,4 @@
+from schemaprovider import UserDataSchemaProvider, RegisterSchemaProvider
+
+userDataSchemaProvider = UserDataSchemaProvider()
+registerSchemaProvider = RegisterSchemaProvider()

--- a/plone/app/users/browser/configure.zcml
+++ b/plone/app/users/browser/configure.zcml
@@ -100,10 +100,10 @@
       />
 
     <utility provides="plone.app.users.schema.IUserDataSchemaProvider"
-             factory="plone.app.users.browser.schemaprovider.UserDataSchemaProvider"/>
+             component="plone.app.users.browser.userDataSchemaProvider"/>
 
     <utility provides="plone.app.users.schema.IRegisterSchemaProvider"
-             factory="plone.app.users.browser.schemaprovider.RegisterSchemaProvider"/>
+             component="plone.app.users.browser.registerSchemaProvider"/>
 
     <subscriber
         for="plone.app.users.browser.schemaeditor.IMemberSchemaContext

--- a/plone/app/users/browser/schemaeditor.py
+++ b/plone/app/users/browser/schemaeditor.py
@@ -22,12 +22,12 @@ from plone.z3cform.layout import FormWrapper
 
 from plone.app.users.schema import (
     IUserDataSchemaProvider,
+    IRegisterSchemaProvider,
     SCHEMA_ANNOTATION,
     SCHEMATA_KEY,
 )
 
 
-CACHE_CONTAINER = {}
 USERS_NAMESPACE = 'http://namespaces.plone.org/supermodel/users'
 USERS_PREFIX = 'users'
 SPLITTER = '_//_'
@@ -131,7 +131,6 @@ def updateSchema(object, event):
 
 
 def applySchema(snew_schema):
-    CACHE_CONTAINER.clear()
     site = getSite()
 
     # get the old schema (currently stored in the annotation)
@@ -181,6 +180,10 @@ def applySchema(snew_schema):
             if field_type == '__portrait__':
                 continue
             pm._delProperty(field_id)
+
+    # re-initialize schema providers
+    getUtility(IUserDataSchemaProvider).initialize()
+    getUtility(IRegisterSchemaProvider).initialize()
 
 
 def model_key(*a, **kw):

--- a/plone/app/users/browser/schemaeditor.py
+++ b/plone/app/users/browser/schemaeditor.py
@@ -91,28 +91,13 @@ class SchemaListingPage(FormWrapper):
     index = ViewPageTemplateFile('schema_layout.pt')
 
 
-def copy_schema(schema, filter_serializable=False):
-    fields = {}
-    for item in schema:
-        if (filter_serializable and not is_serialisable_field(schema[item])):
-            continue
-        fields[item] = schema[item]
-    oschema = SchemaClass(SCHEMATA_KEY, attrs=fields)
-    # copy base tagged values
-    for i in schema.getTaggedValueTags():
-        oschema.setTaggedValue(
-            item, schema.queryTaggedValue(i))
-    finalizeSchemas(oschema)
-    return oschema
-
-
 class MemberSchemaContext(SchemaContext):
     implements(IMemberSchemaContext)
 
     label = _(u"Edit Member Form Fields")
 
     def __init__(self, context, request):
-        schema = getUtility(IUserDataSchemaProvider).getCopyOfSchema()
+        schema = getUtility(IUserDataSchemaProvider).getSchema()
         self.fieldsWhichCannotBeDeleted = ['fullname', 'email']
         self.showSaveDefaults = False
         self.enableFieldsets = False

--- a/plone/app/users/browser/schemaprovider.py
+++ b/plone/app/users/browser/schemaprovider.py
@@ -6,7 +6,6 @@ from Products.CMFPlone.interfaces import IPloneSiteRoot
 
 from .userdatapanel import UserDataPanelAdapter
 from .account import AccountPanelSchemaAdapter
-from .schemaeditor import copy_schema
 
 from .schemaeditor import SCHEMATA_KEY, get_ttw_edited_schema
 from plone.app.users.schema import (
@@ -54,14 +53,6 @@ class UserDataSchemaProvider(BaseMemberSchemaProvider):
         # as schema is a generated supermodel,
         # needed adapters can only be registered at run time
         provideAdapter(UserDataPanelAdapter, (IPloneSiteRoot,), self._schema)
-
-    def getCopyOfSchema(self):
-        schema = self.getSchema()
-        copy = copy_schema(schema, filter_serializable=True)
-        # as schema is a generated supermodel,
-        # needed adapters can only be registered at run time
-        provideAdapter(UserDataPanelAdapter, (IPloneSiteRoot,), copy)
-        return copy
 
 
 class RegisterSchemaProvider(BaseMemberSchemaProvider):

--- a/plone/app/users/tests/flexible_user_registration.rst
+++ b/plone/app/users/tests/flexible_user_registration.rst
@@ -157,9 +157,6 @@ Log in again
     >>> browser.getControl('Login Name').value = 'admin'
     >>> browser.getControl('Password').value = 'secret'
     >>> browser.getControl('Log in').click()
-
-<<<<<<< HEADrol panel form.
-
     >>> browser.open('http://nohost/plone/@@member-registration')
     >>> 'Registration settings' in browser.contents
     True
@@ -175,6 +172,11 @@ Submit form with the same set of fields:
     >>> browser.open('http://nohost/plone/@@member-registration', data)
     >>> 'Changes saved.' in browser.contents
     True
+
+Tear down
+
+    >>> browser.open('http://nohost/plone/member-fields')
+    >>> browser.getLink(url='http://nohost/plone/member-fields/favorite_cms/@@delete').click()
 
 # Check register form with portrait field.
 #


### PR DESCRIPTION
Providing a new adapter everytime we render a form might produce memomry leak.
This PR makes sure we only do that only when the schema actually changes.