### PR TITLE
Provide a new schema adapter only when the TTW schema is changed (rebased)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ CHANGES
   warnings.
   [vincentfretin]
 
+- Provide a new schema adapter only when the TTW schema is changed
+  [ebrehault]
+
 
 2.3 (2015-07-18)
 ----------------

--- a/plone/app/users/browser/schemaeditor.py
+++ b/plone/app/users/browser/schemaeditor.py
@@ -179,7 +179,6 @@ def model_key(*a, **kw):
     return (psite, key)
 
 
-# @ram.cache(model_key)
 def get_ttw_edited_schema():
     data = get_schema()
     if data:
@@ -298,15 +297,6 @@ def set_schema(string, site=None):
     annotations[SCHEMA_ANNOTATION] = string
 
 
-def cache_storage(fun, *args, **kwargs):
-    return CACHE_CONTAINER
-
-
-def cache_key(fun, *args, **kw):
-    return "%s-%s" % (model_key(), args)
-
-
-# @volatile.cache(cache_key, cache_storage)
 def getFromBaseSchema(baseSchema, form_name=None):
     attrs = copySchemaAttrs(baseSchema, form_name)
     ttwschema = get_ttw_edited_schema()

--- a/plone/app/users/browser/userdatapanel.py
+++ b/plone/app/users/browser/userdatapanel.py
@@ -12,7 +12,7 @@ from plone.app.users.browser.account import AccountPanelSchemaAdapter
 from plone.registry.interfaces import IRegistry
 
 from ..schema import IUserDataSchema
-from .schemaeditor import getFromBaseSchema
+from .schemaeditor import getFromBaseSchema, CACHE_CONTAINER
 
 
 class UserDataPanelAdapter(AccountPanelSchemaAdapter):
@@ -76,14 +76,16 @@ class UserDataPanel(AccountPanelForm):
 
 
 def getUserDataSchema():
-    schema = getFromBaseSchema(
-        IUserDataSchema,
-        form_name=u'In User Profile'
-    )
-    # as schema is a generated supermodel,
-    # needed adapters can only be registered at run time
-    provideAdapter(UserDataPanelAdapter, (IPloneSiteRoot,), schema)
-    return schema
+    if 'userdata' not in CACHE_CONTAINER:
+        CACHE_CONTAINER['userdata'] = getFromBaseSchema(
+            IUserDataSchema,
+            form_name=u'In User Profile'
+        )
+        # as schema is a generated supermodel,
+        # needed adapters can only be registered at run time
+        provideAdapter(
+            UserDataPanelAdapter, (IPloneSiteRoot,), CACHE_CONTAINER['userdata'])
+    return CACHE_CONTAINER['userdata']
 
 
 class UserDataConfiglet(UserDataPanel):

--- a/plone/app/users/tests/flexible_user_registration.rst
+++ b/plone/app/users/tests/flexible_user_registration.rst
@@ -64,10 +64,6 @@ Check default form fields are not editable::
 Let's add favorite_cms to the list of registration form fields.
 (Setting this by hand since add/remove widget doesn't work properly without javascript)
 
-Getting rid of the 'mail_me' user registration field:
-
-    >>> portal.portal_properties.site_properties._updateProperty('user_registration_fields', ['fullname', 'username', 'email', 'password'])
-    >>> transaction.commit()
 
 We should be able to add a field::
 
@@ -158,64 +154,51 @@ Log in again
     >>> browser.getControl('Password').value = 'secret'
     >>> browser.getControl('Log in').click()
 
-<<<<<<< HEADrol panel form.
+Add portrait to registration form
 
-    >>> browser.open('http://nohost/plone/@@member-registration')
-    >>> 'Registration settings' in browser.contents
+    >>> browser.open('http://nohost/plone/@@member-fields')
+    >>> browser.getLink(url='http://nohost/plone/member-fields/portrait').click()
+    >>> chkboxes = browser.getControl(name='form.widgets.IUserFormSelection.forms:list')
+    >>> chkboxes.controls[0].selected = True
+    >>> chkboxes.controls[1].selected = True
+    >>> browser.getControl(label='Save').click()
+
+Check register form with portrait field.
+
+    >>> browser.open('http://nohost/plone/logout')
+    >>> browser.open('http://nohost/plone/@@register')
+    >>> 'Registration form' in browser.contents
     True
-
-Submit form with the same set of fields:
-
-    >>> data = '&'.join([
-    ...     'form.widgets.user_registration_fields:list=username',
-    ...     'form.widgets.user_registration_fields:list=email',
-    ...     'form.actions.save=Save',
-    ...     'form.buttons.save=Save',
-    ...     '_authenticator=' + getAuth()])
-    >>> browser.open('http://nohost/plone/@@member-registration', data)
-    >>> 'Changes saved.' in browser.contents
+    >>> 'Portrait' in browser.contents
     True
+    >>> from pkg_resources import resource_stream
+    >>> portrait_file = resource_stream("plone.app.users.tests", 'onepixel.jpg')
+    >>> browser.getControl(name='form.widgets.portrait').add_file(portrait_file, "image/jpg", "onepixel.jpg")
+    >>> browser.getControl('User Name').value = 'testuser'
+    >>> browser.getControl('E-mail').value = 'test@example.com'
+    >>> browser.getControl('Password').value = 'testpassword'
+    >>> browser.getControl('Confirm password').value = 'testpassword'
+    >>> browser.getControl('Register').click()
+    >>> browser.contents
+    '...Welcome!...You have been registered...'
 
-# Check register form with portrait field.
-#
-#     >>> portal.portal_properties.site_properties._updateProperty('user_registration_fields', ['portrait'# ])
-#     >>> browser.open('http://nohost/plone/@@register')
-#     >>> 'Registration form' in browser.contents
-#     True
-#     >>> 'Portrait' in browser.contents
-#     True
-#     >>> from pkg_resources import resource_stream
-#     >>> portrait_file = resource_stream("plone.app.users.tests", 'onepixel.jpg')
-#     >>> browser.getControl(name='form.widgets.portrait').add_file(portrait_file, "image/jpg", "onepixel.# jpg")
-#     >>> browser.getControl('User Name').value = 'testuser'
-#     >>> browser.getControl('E-mail').value = 'test@example.com'
-#     >>> browser.getControl('Password').value = 'testpassword'
-#     >>> browser.getControl('Confirm password').value = 'testpassword'
-#     >>> browser.getControl('Register').click()
-#     >>> browser.contents
-#     '...Welcome!...You have been registered...'
-#
-# Check more validation errors. Test Confirmation Password and invalid
-# email, and reserved user name validations:
-#
-#     >>> portal.portal_properties.site_properties._updateProperty('user_registration_fields', [# 'username', 'email', 'password', 'mail_me'])
-#     >>> browser.open('http://nohost/plone/@@register')
-#     >>> 'Registration form' in browser.contents
-#     True
-#     >>> browser.getControl('User Name').value = 'plone'
-#     >>> browser.getControl('E-mail').value = 'invalid email'
-#     >>> browser.getControl('Password').value = 'testpassword'
-#     >>> browser.getControl('Confirm password').value = 'testpassword2'
-#     >>> browser.getControl('Register').click()
-#     >>> browser.contents
-#     '...There were errors...'
-#     >>> browser.contents
-#     '...This username is reserved...Invalid email address...Passwords do not match...'
-#
-# Now also check username which is already in use:
-#
-#     >>> browser.getControl('User Name').value = 'admin'
-#     >>> browser.getControl('Register').click()
-#     >>> browser.contents
-#     '...The login name you selected is already in use...'
-#
+Check more validation errors. Test Confirmation Password and invalid
+email, and reserved user name validations:
+    >>> browser.open('http://nohost/plone/@@register')
+    >>> 'Registration form' in browser.contents
+    True
+    >>> browser.getControl('User Name').value = 'plone'
+    >>> browser.getControl('E-mail').value = 'invalid email'
+    >>> browser.getControl('Password').value = 'testpassword'
+    >>> browser.getControl('Confirm password').value = 'testpassword2'
+    >>> browser.getControl('Register').click()
+    >>> browser.contents
+    '...There were errors...'
+    >>> browser.contents
+    '...Invalid email address...This username is reserved...Passwords do not match...'
+
+Now also check username which is already in use:
+    >>> browser.getControl('User Name').value = 'admin'
+    >>> browser.getControl('Register').click()
+    >>> browser.contents
+    '...The login name you selected is already in use...'


### PR DESCRIPTION
Providing a new adapter everytime we render a form might produce memory leak.
This PR makes sure we only do that only when the schema actually changes.