### PR TITLE
Fix bug when registering a user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fix bug when registering a user by adding a schema-setter to
+  UserDataPanelAdapter.
+  [pbauer]
 
 
 2.3.4 (2015-11-28)

--- a/plone/app/users/browser/userdatapanel.py
+++ b/plone/app/users/browser/userdatapanel.py
@@ -22,7 +22,17 @@ class UserDataPanelAdapter(AccountPanelSchemaAdapter):
 
     @property
     def schema(self):
-        return getUserDataSchema()
+        # prevent infinite recursion when accessing the schema via bypassing
+        # __getattr__ of self
+        try:
+            return object.__getattribute__(self, '_schema')
+        except AttributeError:
+            object.__setattr__(self, '_schema', getUserDataSchema())
+        return object.__getattribute__(self, '_schema')
+
+    @schema.setter
+    def schema(self, value):
+        self._schema = value
 
     def get_email(self):
         return self._getProperty('email')


### PR DESCRIPTION
This pr adds a setter to the attribute ``schema`` of UserDataPanelAdapter.

When registering a user the properties-setter in ``plone.app.users.browser.register.BaseRegistrationForm.applyProperties`` uses ``adapter.schema = schema`` to set schema on ``plone.app.users.browser.userdatapanel.UserDataPanelAdapter``.

That operation used the ``__setattr__``-method of its super but ``UserDataPanelAdapter.schema`` was a property so that had to fail. We also use  ``object.__getattribute__`` to bypass the getter of the super that checked for schema and would result in a infinite recursion. 
