### PR TITLE
Ensured partial searching utility for users in 'Search for users' page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,11 @@ CHANGES
 2.3.6 (unreleased)
 ------------------
 
-New:
-
-- *add item here*
-
 Fixes:
 
-- *add item here*
+- Ensured partial searching utility for users in 'Search for users' page
+  Fixes https://github.com/plone/Products.CMFPlone/issues/1499
+  [kkhan]
 
 
 2.3.5 (2016-02-11)

--- a/plone/app/users/browser/membersearch.py
+++ b/plone/app/users/browser/membersearch.py
@@ -23,22 +23,21 @@ class IMemberSearchSchema(model.Schema):
         title=_(u'label_name', default=u'Name'),
         description=_(
             u'help_search_name',
-            default=u'Find users with login name'),
+            default=u'Find users whose login name contain'),
         required=False,
     )
     email = schema.TextLine(
         title=_(u'label_email', default=u'E-mail'),
         description=_(
             u'help_search_email',
-            default=u'Find users with email address'),
-        constraint=checkEmailAddress,
+            default=u'Find users whose email address contain'),
         required=False,
     )
     fullname = schema.TextLine(
         title=_(u'label_fullname', default=u'Full Name'),
         description=_(
             u'help_search_fullname',
-            default=u'Find users with full names'),
+            default=u'Find users whose full names contain'),
         required=False,
     )
     # disabled: https://dev.plone.org/ticket/13862

--- a/plone/app/users/browser/membersearch.py
+++ b/plone/app/users/browser/membersearch.py
@@ -23,14 +23,14 @@ class IMemberSearchSchema(model.Schema):
         title=_(u'label_name', default=u'Name'),
         description=_(
             u'help_search_name',
-            default=u'Find users whose login names contain.'),
+            default=u'Find users with login name'),
         required=False,
     )
     email = schema.TextLine(
         title=_(u'label_email', default=u'E-mail'),
         description=_(
             u'help_search_email',
-            default=u'Find users whose email addresses contain.'),
+            default=u'Find users with email address'),
         constraint=checkEmailAddress,
         required=False,
     )
@@ -38,7 +38,7 @@ class IMemberSearchSchema(model.Schema):
         title=_(u'label_fullname', default=u'Full Name'),
         description=_(
             u'help_search_fullname',
-            default=u'Return users with full names containing this value.'),
+            default=u'Find users with full names'),
         required=False,
     )
     # disabled: https://dev.plone.org/ticket/13862


### PR DESCRIPTION
When clicking on <b>Users</b> tab, 'Search For Users' page shows some ambiguity in search criteria like--
<i>Find users whose email addresses contain.</i> looks like a partial search criteria, but its not. User has to enter qualified valid email in order to proceed.

So I propose to change the `default` to make it look that way.
