### PR TITLE
Fixed KeyError email on personal preferences form.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ CHANGES
 
 Fixes:
 
+- Fixed KeyError email on personal preferences form.  This could
+  happen when email is used as login name.  Fixes
+  https://github.com/plone/plone.app.users/issues/56 and
+  https://github.com/plone/Products.CMFPlone/issues/1146
+  [maurits]
+
 - Ensured partial searching utility for users in 'Search for users' page
   Fixes https://github.com/plone/Products.CMFPlone/issues/1499
   [kkhan]

--- a/plone/app/users/browser/account.py
+++ b/plone/app/users/browser/account.py
@@ -206,8 +206,10 @@ class AccountPanelForm(AutoExtensibleForm, form.Form):
         CheckAuthenticator(self.request)
         data, errors = self.extractData()
 
-        # extra validation for email
-        self.validate_email(action, data)
+        # Extra validation for email, when it is there.  email is not in the
+        # data when you are at the personal-preferences page.
+        if 'email' in data:
+            self.validate_email(action, data)
 
         if action.form.widgets.errors:
             self.status = self.formErrorsMessage


### PR DESCRIPTION
This could happen when email is used as login name.

Fixes https://github.com/plone/plone.app.users/issues/56
And https://github.com/plone/Products.CMFPlone/issues/1146
