### PR TITLE
Apply hotfix 20160830 master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Give a 404 when the user-information form is called with a not
+  existing userid.  [maurits]
+
 - Don't show unescaped user id in user-information form.
   This applies PloneHotfix20160830.  [maurits]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Don't show unescaped user id in user-information form.
+  This applies PloneHotfix20160830.  [maurits]
 
 
 2.3.7 (2016-08-18)

--- a/plone/app/users/browser/userdatapanel.py
+++ b/plone/app/users/browser/userdatapanel.py
@@ -15,6 +15,9 @@ from plone.registry.interfaces import IRegistry
 from ..schema import IUserDataSchema
 from .schemaeditor import getFromBaseSchema
 
+import cgi
+
+
 
 class UserDataPanelAdapter(AccountPanelSchemaAdapter):
     """One does not simply set portrait, email might be used to login with.
@@ -72,7 +75,7 @@ class UserDataPanel(AccountPanelForm):
             return _(
                 u'description_personal_information_form_otheruser',
                 default='Change personal information for $name',
-                mapping={'name': userid}
+                mapping={'name': cgi.escape(userid)}
             )
         else:
             # editing my own profile

--- a/plone/app/users/browser/userdatapanel.py
+++ b/plone/app/users/browser/userdatapanel.py
@@ -11,6 +11,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.users.browser.account import AccountPanelForm
 from plone.app.users.browser.account import AccountPanelSchemaAdapter
 from plone.registry.interfaces import IRegistry
+from zExceptions import NotFound
 
 from ..schema import IUserDataSchema
 from .schemaeditor import getFromBaseSchema
@@ -85,6 +86,11 @@ class UserDataPanel(AccountPanelForm):
             )
 
     def __call__(self):
+        userid = self.request.form.get('userid')
+        if userid:
+            mt = getToolByName(self.context, 'portal_membership')
+            if mt.getMemberById(userid) is None:
+                raise NotFound('User does not exist.')
         self.request.set('disable_border', 1)
         return super(UserDataPanel, self).__call__()
 

--- a/plone/app/users/tests/test_user_data_panel.py
+++ b/plone/app/users/tests/test_user_data_panel.py
@@ -1,0 +1,30 @@
+from plone.app.users.browser.userdatapanel import UserDataPanel
+from plone.app.users.testing import PLONE_APP_USERS_FUNCTIONAL_TESTING
+from zope.i18n import translate
+
+import unittest
+
+
+class TestUserDataPanel(unittest.TestCase):
+
+    layer = PLONE_APP_USERS_FUNCTIONAL_TESTING
+
+    def test_regression(self):
+        portal = self.layer['portal']
+        request = self.layer['request']
+        request.form.update({
+            'userid': 'admin'
+        })
+        form = UserDataPanel(portal, request)
+        description = translate(form.description, context=request)
+        self.assertTrue('admin' in description)
+
+    def test_escape_html(self):
+        portal = self.layer['portal']
+        request = self.layer['request']
+        request.form.update({
+            'userid': 'admin<script>alert("userid")</script>'
+        })
+        form = UserDataPanel(portal, request)
+        description = translate(form.description, context=request)
+        self.assertTrue('<script>' not in description)

--- a/plone/app/users/tests/test_user_data_panel.py
+++ b/plone/app/users/tests/test_user_data_panel.py
@@ -1,3 +1,4 @@
+from zExceptions import NotFound
 from plone.app.users.browser.userdatapanel import UserDataPanel
 from plone.app.users.testing import PLONE_APP_USERS_FUNCTIONAL_TESTING
 from zope.i18n import translate
@@ -18,6 +19,8 @@ class TestUserDataPanel(unittest.TestCase):
         form = UserDataPanel(portal, request)
         description = translate(form.description, context=request)
         self.assertTrue('admin' in description)
+        # form can be called without raising exception.
+        self.assertTrue(form())
 
     def test_escape_html(self):
         portal = self.layer['portal']
@@ -28,3 +31,4 @@ class TestUserDataPanel(unittest.TestCase):
         form = UserDataPanel(portal, request)
         description = translate(form.description, context=request)
         self.assertTrue('<script>' not in description)
+        self.assertRaises(NotFound, form)


### PR DESCRIPTION
This also adds something that is not in the hotfix: when the userid that is given in the request does not exist, raise a 404 NotFound error.
The master branch is for Plone 5. On Plone 4.3 the current behavior is that you get an AttributeError. That made 4.3 not vulnerable to this part of the hotfix. I intend to raise a 404 on 4.3 too.