### PR TITLE
Apply hotfix 20160830 12x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New features:
 
 Bug fixes:
 
+- Give a 404 when the user-information form is called with a not
+  existing userid.  [maurits]
+
 - Don't show unescaped user id in user-information form.
   This applies PloneHotfix20160830.  [maurits]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,14 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
-New:
+New features:
 
 - *add item here*
 
-Fixes:
+Bug fixes:
 
-- *add item here*
+- Don't show unescaped user id in user-information form.
+  This applies PloneHotfix20160830.  [maurits]
 
 
 1.2.4 (2016-02-24)

--- a/plone/app/users/browser/personalpreferences.py
+++ b/plone/app/users/browser/personalpreferences.py
@@ -26,6 +26,8 @@ from Products.CMFPlone.utils import set_own_login_name, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 
+import cgi
+
 
 class IPersonalPreferences(Interface):
 
@@ -298,7 +300,7 @@ class UserDataPanel(AccountPanelForm):
             #editing someone else's profile
             return _(u'description_personal_information_form_otheruser',
                      default='Change personal information for $name',
-                     mapping={'name': self.userid})
+                     mapping={'name': cgi.escape(self.userid)})
         else:
             #editing my own profile
             return _(u'description_personal_information_form',

--- a/plone/app/users/browser/personalpreferences.py
+++ b/plone/app/users/browser/personalpreferences.py
@@ -25,6 +25,7 @@ from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.utils import set_own_login_name, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
+from zExceptions import NotFound
 
 import cgi
 
@@ -321,6 +322,14 @@ class UserDataPanel(AccountPanelForm):
     def getPortrait(self):
         context = aq_inner(self.context)
         return context.portal_membership.getPersonalPortrait()
+
+    def __call__(self):
+        if self.userid:
+            context = aq_inner(self.context)
+            mt = getToolByName(context, 'portal_membership')
+            if mt.getMemberById(self.userid) is None:
+                raise NotFound('User does not exist.')
+        return super(UserDataPanel, self).__call__()
 
 
 class UserDataConfiglet(UserDataPanel):

--- a/plone/app/users/tests/test_user_data_panel.py
+++ b/plone/app/users/tests/test_user_data_panel.py
@@ -1,5 +1,6 @@
 from plone.app.users.browser.personalpreferences import UserDataPanel
 from plone.app.users.tests.base import TestCase
+from zExceptions import NotFound
 from zope.i18n import translate
 
 
@@ -14,6 +15,8 @@ class TestUserDataPanel(TestCase):
         form = UserDataPanel(portal, request)
         description = translate(form.description, context=request)
         self.assertTrue('admin' in description)
+        # form can be called without raising exception.
+        self.assertTrue(form())
 
     def test_escape_html(self):
         portal = self.portal
@@ -24,3 +27,4 @@ class TestUserDataPanel(TestCase):
         form = UserDataPanel(portal, request)
         description = translate(form.description, context=request)
         self.assertTrue('<script>' not in description)
+        self.assertRaises(NotFound, form)

--- a/plone/app/users/tests/test_user_data_panel.py
+++ b/plone/app/users/tests/test_user_data_panel.py
@@ -1,0 +1,26 @@
+from plone.app.users.browser.personalpreferences import UserDataPanel
+from plone.app.users.tests.base import TestCase
+from zope.i18n import translate
+
+
+class TestUserDataPanel(TestCase):
+
+    def test_regression(self):
+        portal = self.portal
+        request = portal.REQUEST
+        request.form.update({
+            'userid': 'admin'
+        })
+        form = UserDataPanel(portal, request)
+        description = translate(form.description, context=request)
+        self.assertTrue('admin' in description)
+
+    def test_escape_html(self):
+        portal = self.portal
+        request = portal.REQUEST
+        request.form.update({
+            'userid': 'admin<script>alert("userid")</script>'
+        })
+        form = UserDataPanel(portal, request)
+        description = translate(form.description, context=request)
+        self.assertTrue('<script>' not in description)


### PR DESCRIPTION
This also adds something that is not in the hotfix: when the userid that is given in the request does not exist, raise a 404 NotFound error.
On Plone 4.3 the current behavior is that you get an AttributeError. That made 4.3 not vulnerable to this part of the hotfix, (though still good to fix).