### PR TITLE
Import activatePluginInterfaces from canonical location in PlonePAS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Import ``activatePluginInterfaces`` from canonical location in PlonePAS.
+  [maurits]
+
 - Provide the UserDataPanelAdapter for INavigationRoot, so @@personal-information
   is not broken with p.a.multilingual
   [ebrehault]

--- a/plone/app/users/tests/base.py
+++ b/plone/app/users/tests/base.py
@@ -16,7 +16,7 @@ from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.CMFPlone.interfaces.controlpanel import IMailSchema
 from Products.CMFPlone.tests.utils import MockMailHost
 from Products.MailHost.interfaces import IMailHost
-from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
+from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 from Products.PluggableAuthService.interfaces.plugins import IValidationPlugin
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Acquisition',
         'Products.CMFCore',
         'Products.CMFPlone >= 5.1a2',
-        'Products.PlonePAS',
+        'Products.PlonePAS >= 5.0.1',
         'Products.statusmessages',
         'ZODB3',
         'Zope2 >= 2.12.3',


### PR DESCRIPTION
Requires PlonePAS 5.0.1.