### PR TITLE
Fix browser test to use name of user/password field instead of label.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Fix browser test to use name of user/password field instead of label.
+  [jensens]
+
 - Import ``activatePluginInterfaces`` from canonical location in PlonePAS.
   [maurits]
 

--- a/plone/app/users/tests/duplicate_email.rst
+++ b/plone/app/users/tests/duplicate_email.rst
@@ -32,8 +32,8 @@ Login as user two:
     >>> browser.open('http://nohost/plone/')
     >>> browser.getLink('Log in').click()
 
-    >>> browser.getControl('E-mail').value = 'usertwo@example.com'
-    >>> browser.getControl('Password').value = 'secret'
+    >>> browser.getControl(name='__ac_name').value = 'usertwo@example.com'
+    >>> browser.getControl(name='__ac_password').value = 'secret'
     >>> browser.getControl('Log in').click()
     >>> 'Login failed' in browser.contents
     False

--- a/plone/app/users/tests/email_login.rst
+++ b/plone/app/users/tests/email_login.rst
@@ -22,8 +22,8 @@ Configure security
 ------------------
 
     >>> browser.open('http://nohost/plone/login_form')
-    >>> browser.getControl('Login Name').value = SITE_OWNER_NAME
-    >>> browser.getControl('Password').value = SITE_OWNER_PASSWORD
+    >>> browser.getControl(name='__ac_name').value = SITE_OWNER_NAME
+    >>> browser.getControl(name='__ac_password').value = SITE_OWNER_PASSWORD
     >>> browser.getControl('Log in').click()
 
     >>> browser.open('http://nohost/plone/@@security-controlpanel')


### PR DESCRIPTION
see https://github.com/plone/Products.CMFPlone/issues/2092 - this one can be merged independently afaict