### PR TITLE
Remove unneeded arrow next to Site Setup button in "Edit Member Form Fields" controlpanel

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,2 @@
+Remove unneeded arrow next to Site Setup button in "Edit Member Form Fields" controlpanel.
+[vincentfretin]

--- a/plone/app/users/browser/schema_layout.pt
+++ b/plone/app/users/browser/schema_layout.pt
@@ -14,7 +14,7 @@
      tal:attributes="href string:$portal_url/@@overview-controlpanel"
      i18n:translate="">
       Site Setup
-  </a> &rsaquo;
+  </a>
 
   <h1 class="documentFirstHeading" i18n:translate="">Edit Member Form Fields</h1>
 


### PR DESCRIPTION
This fixes https://github.com/plone/plone.app.users/issues/93