### PR TITLE
Test fix: remove deprecated ustring handling, which is only needed on Py2

### DIFF
--- a/news/3305.bugfix
+++ b/news/3305.bugfix
@@ -1,0 +1,2 @@
+Test fix: remove deprecated ustring handling, which is only needed on Python 2.
+[maurits]

--- a/plone/app/users/tests/personal_preferences_prefs_user_details.rst
+++ b/plone/app/users/tests/personal_preferences_prefs_user_details.rst
@@ -114,7 +114,5 @@ form::
     >>> browser.getControl('Cancel').click()
     >>> 'Changes canceled.' in browser.contents
     True
-    >>> import six
-    >>> searchstring = '?userid:utf8:ustring=test_user_1_' if six.PY2 else '?userid=test_user_1_'
-    >>> searchstring in browser.url
+    >>> '?userid=test_user_1_' in browser.url
     True

--- a/plone/app/users/tests/test_doctests.py
+++ b/plone/app/users/tests/test_doctests.py
@@ -3,8 +3,6 @@ from plone.app.users.testing import PLONE_APP_USERS_FUNCTIONAL_TESTING
 from plone.testing import layered
 
 import doctest
-import re
-import six
 import unittest
 
 
@@ -30,16 +28,6 @@ optionflags = (
 )
 
 
-class Py23DocChecker(doctest.OutputChecker):
-    def check_output(self, want, got, optionflags):
-        if six.PY2:
-            got = got.replace('Unauthorized', 'zExceptions.unauthorized.Unauthorized')
-            got = got.replace(':utf8:ustring', '')
-            got = re.sub("u'(.*?)'", "'\\1'", got)
-            want = re.sub("b'(.*?)'", "'\\1'", want)
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
-
-
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([
@@ -48,7 +36,6 @@ def test_suite():
                 'tests/{0}'.format(test_file),
                 package='plone.app.users',
                 optionflags=optionflags,
-                checker=Py23DocChecker(),
             ),
             layer=PLONE_APP_USERS_FUNCTIONAL_TESTING)
         for test_file in doc_tests

--- a/plone/app/users/tests/userdata_prefs_user_details.rst
+++ b/plone/app/users/tests/userdata_prefs_user_details.rst
@@ -15,10 +15,6 @@ Set Up
     >>> membership = portal.portal_membership
 
     >>> user_information_url = 'http://nohost/plone/@@user-information?userid={0}'.format(TEST_USER_ID)
-    >>> import six
-    >>> if six.PY2:
-    ...     user_information_url = 'http://nohost/plone/@@user-information?userid:utf8:ustring=test_user_1_'
-
     >>> browser = Browser(app)
     >>> browser.handleErrors = False
 


### PR DESCRIPTION
Part of https://github.com/plone/Products.CMFPlone/issues/3305