### PR TITLE
Added a timezone setter

### DIFF
--- a/news/109.bugfix
+++ b/news/109.bugfix
@@ -1,0 +1,1 @@
+Ensure that, when no timezone is selected, the value of the stored timezone is an empty string

--- a/plone/app/users/browser/account.py
+++ b/plone/app/users/browser/account.py
@@ -138,6 +138,16 @@ class AccountPanelSchemaAdapter(object):
             value = ''
         return self._setProperty('wysiwyg_editor', value)
 
+    @property
+    def timezone(self):
+        return self._getProperty('timezone')
+
+    @timezone.setter
+    def timezone(self, value):
+        if value is None:
+            value = ''
+        return self._setProperty('timezone', value)
+
 
 @implementer(IAccountPanelForm)
 class AccountPanelForm(AutoExtensibleForm, form.Form):


### PR DESCRIPTION
Add a timezone setter that prevents `None` to be stored as a timezone.
Save it as an empty string instead.

Fixes #109

Please also merge https://github.com/plone/Products.CMFPlone/pull/3625