### PR TITLE
For user schemas use a volatile cache on the request instead of on the portal.

### DIFF
--- a/news/76.bugfix
+++ b/news/76.bugfix
@@ -1,0 +1,4 @@
+For user schemas use a volatile cache on the request instead of on the portal.
+This prevents seeing an empty user profile when you have custom user schemas.
+This fixes `issue 76 <https://github.com/plone/plone.app.users/issues/76>`_.
+[maurits]

--- a/plone/app/users/browser/register.py
+++ b/plone/app/users/browser/register.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
-from Acquisition import aq_inner
 from plone.app.users.browser.account import AccountPanelSchemaAdapter
+from plone.app.users.browser.account import getSchema
 from plone.app.users.browser.interfaces import ILoginNameGenerator
 from plone.app.users.browser.interfaces import IUserIdGenerator
-from plone.app.users.browser.schemaeditor import getFromBaseSchema
 from plone.app.users.schema import IAddUserSchema
 from plone.app.users.schema import ICombinedRegisterSchema
 from plone.app.users.schema import IRegisterSchema
@@ -17,10 +16,8 @@ from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.permissions import ManagePortal
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
-from Products.CMFPlone.utils import get_portal
 from Products.CMFPlone.utils import normalizeString
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
@@ -34,7 +31,6 @@ from ZODB.POSException import ConflictError
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.component import provideAdapter
 from zope.component import queryUtility
 from zope.schema import getFieldNames
 
@@ -47,16 +43,11 @@ RENAME_AFTER_CREATION_ATTEMPTS = 100
 
 
 def getRegisterSchema():
-    portal = get_portal()
-    schema = getattr(portal, '_v_register_schema', None)
-    if schema is None:
-        portal._v_register_schema = schema = getFromBaseSchema(
-            ICombinedRegisterSchema,
-            form_name=u'On Registration'
-        )
-        # as schema is a generated supermodel,
-        # needed adapters can only be registered at run time
-        provideAdapter(AccountPanelSchemaAdapter, (IPloneSiteRoot,), schema)
+    schema = getSchema(
+        ICombinedRegisterSchema,
+        AccountPanelSchemaAdapter,
+        form_name='On Registration',
+    )
     return schema
 
 
@@ -722,4 +713,3 @@ class AddUserForm(BaseRegistrationForm):
         self.request.response.redirect(
             self.context.absolute_url() +
             '/@@usergroup-userprefs?searchstring=' + user_id)
-

--- a/plone/app/users/browser/userdatapanel.py
+++ b/plone/app/users/browser/userdatapanel.py
@@ -1,21 +1,18 @@
 # -*- coding: utf-8 -*-
 from AccessControl.SecurityManagement import getSecurityManager
-from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.users.browser.account import AccountPanelForm
 from plone.app.users.browser.account import AccountPanelSchemaAdapter
-from plone.app.users.browser.schemaeditor import getFromBaseSchema
+from plone.app.users.browser.account import getSchema
 from plone.app.users.schema import IUserDataSchema
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.CMFPlone.utils import get_portal
 from Products.CMFPlone.utils import set_own_login_name
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zExceptions import NotFound
 from zope.component import getUtility
-from zope.component import provideAdapter
 
 try:
     from html import escape
@@ -103,23 +100,7 @@ def getUserDataSchema():
     form_name = u'In User Profile'
     if getSecurityManager().checkPermission('Manage portal', portal):
         form_name = None
-    if form_name:
-        schema = getattr(portal, '_v_userdata_schema', None)
-    else:
-        schema = getattr(portal, '_v_userdata_manager_schema', None)
-    if schema is None:
-        schema = getFromBaseSchema(
-            IUserDataSchema,
-            form_name=form_name
-        )
-        if form_name:
-            portal._v_userdata_schema = schema
-        else:
-            portal._v_userdata_manager_schema = schema
-        # as schema is a generated supermodel,
-        # needed adapters can only be registered at run time
-        provideAdapter(UserDataPanelAdapter, (IPloneSiteRoot,), schema)
-        provideAdapter(UserDataPanelAdapter, (INavigationRoot,), schema)
+    schema = getSchema(IUserDataSchema, UserDataPanelAdapter, form_name=form_name)
     return schema
 
 
@@ -127,4 +108,3 @@ class UserDataConfiglet(UserDataPanel):
     """Control panel version of the userdata panel"""
     template = ViewPageTemplateFile('account-configlet.pt')
     tab = "userdata"
-

--- a/plone/app/users/tests/test_schema_types.py
+++ b/plone/app/users/tests/test_schema_types.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from pkg_resources import resource_stream
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.users.setuphandlers import import_schema
-from plone.app.users.testing import PLONE_APP_USERS_FUNCTIONAL_TESTING
 from plone.testing.z2 import Browser
 from Products.GenericSetup.tests.common import DummyImportContext
 from plone.app.users.tests.base import BaseTestCase
@@ -105,6 +106,7 @@ class TestSchema(BaseTestCase):
         transaction.commit()
 
         self.browser = Browser(self.layer['app'])
+        self.browser.handleErrors = False
         self.request = self.layer['request']
 
     def test_schema_types(self):
@@ -155,3 +157,95 @@ class TestSchema(BaseTestCase):
         self.assertEqual(member.getProperty('pi'), 3.14)
         self.assertTrue(isinstance(member.getProperty('vegetarian'), bool))
         self.assertEqual(member.getProperty('vegetarian'), True)
+
+    def test_regression_76_user_information(self):
+        # Test that issue 76 does not return: user info sometimes appears empty.
+        # https://github.com/plone/plone.app.users/issues/76
+        # Here we test as admin.
+        portal_url = self.portal.absolute_url()
+        self.browser.open(portal_url)
+        self.browser.getLink('Log in').click()
+        self.browser.getControl('Login Name').value = SITE_OWNER_NAME
+        self.browser.getControl('Password').value = SITE_OWNER_PASSWORD
+        self.browser.getControl('Log in').click()
+
+        # Set information for the test user.
+        info_page = f"{portal_url}/@@user-information?userid={TEST_USER_ID}"
+        self.browser.open(info_page)
+        self.browser.getControl('Full Name').value = 'Isaac Newton'
+        self.browser.getControl('Email').value = 'isaac@cambridge.com'
+        self.browser.getControl('Age').value = '40'
+        self.browser.getControl('Save').click()
+
+        # Open the page again, check that the information is set.
+        self.browser.open(info_page)
+        self.assertEqual(self.browser.getControl('Full Name').value, 'Isaac Newton')
+        self.assertEqual(self.browser.getControl('Email').value, 'isaac@cambridge.com')
+        self.assertEqual(self.browser.getControl('Age').value, '40')
+
+        # Opening the new-user/register page used to be enough to trigger the problem.
+        self.browser.open(f"{portal_url}/@@new-user")
+
+        # Any next calls to the user or personal information pages would show empty.
+        self.browser.open(info_page)
+        self.assertEqual(self.browser.getControl('Full Name').value, 'Isaac Newton')
+        self.assertEqual(self.browser.getControl('Email').value, 'isaac@cambridge.com')
+        self.assertEqual(self.browser.getControl('Age').value, '40')
+
+    def _enable_self_registration(self):
+        from plone.registry.interfaces import IRegistry
+        from Products.CMFPlone.interfaces import ISecuritySchema
+        from zope.component import getUtility
+
+        self.portal.manage_permission('Add portal member', roles=['Anonymous'])
+        registry = getUtility(IRegistry)
+        security_settings = registry.forInterface(ISecuritySchema, prefix="plone")
+        security_settings.enable_user_pwd_choice = True
+        transaction.commit()
+
+    def test_regression_76_personal_information(self):
+        # Test that issue 76 does not return: personal info sometimes appears empty.
+        # https://github.com/plone/plone.app.users/issues/76
+        # Here we test as user.
+        portal_url = self.portal.absolute_url()
+        self.browser.open(portal_url)
+        self.browser.getLink('Log in').click()
+        self.browser.getControl('Login Name').value = TEST_USER_NAME
+        self.browser.getControl('Password').value = TEST_USER_PASSWORD
+        self.browser.getControl('Log in').click()
+
+        # Set information for the test user.
+        info_page = f"{portal_url}/@@personal-information"
+        self.browser.open(info_page)
+        self.browser.getControl('Full Name').value = 'Isaac Newton'
+        self.browser.getControl('Email').value = 'isaac@cambridge.com'
+        self.browser.getControl('Age').value = '40'
+        self.browser.getControl('Save').click()
+
+        # Open the page again, check that the information is set.
+        self.browser.open(info_page)
+        self.assertEqual(self.browser.getControl('Full Name').value, 'Isaac Newton')
+        self.assertEqual(self.browser.getControl('Email').value, 'isaac@cambridge.com')
+        self.assertEqual(self.browser.getControl('Age').value, '40')
+
+        # Enable self registration.
+        self._enable_self_registration()
+
+        # Opening the new-user/register page used to be enough to trigger the problem.
+        # Logout, try it, and login again.
+        self.browser.open(f"{portal_url}/@@logout")
+        self.browser.open(f"{portal_url}/@@register")
+        # Check that the registration page is loading correctly.
+        self.assertNotIn("This site doesn't have a valid email setup", self.browser.contents)
+        self.assertIn("Enter your new password.", self.browser.contents)
+
+        self.browser.open(f"{portal_url}/@@login")
+        self.browser.getControl('Login Name').value = TEST_USER_NAME
+        self.browser.getControl('Password').value = TEST_USER_PASSWORD
+        self.browser.getControl('Log in').click()
+
+        # Any next calls to the user or personal information pages would show empty.
+        self.browser.open(info_page)
+        self.assertEqual(self.browser.getControl('Full Name').value, 'Isaac Newton')
+        self.assertEqual(self.browser.getControl('Email').value, 'isaac@cambridge.com')
+        self.assertEqual(self.browser.getControl('Age').value, '40')


### PR DESCRIPTION
This prevents seeing an empty user profile when you have custom user schemas.
This fixes https://github.com/plone/plone.app.users/issues/76.
Includes two regression tests, although one of them already passes with the original code.

It's a bit ugly, but then the original code was ugly as well. There may be nicer ways to solve this, but I think such a solution would be a more drastic overhaul, and I would like to avoid that.