### PR TITLE
122 portrait image file not supported by pil

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -7,4 +7,4 @@ commit-id = "cfffba8c"
 
 [pyproject]
 codespell_ignores = "complet,exemple"
-dependencies_ignores = "['Products.CMFPlone']"
+dependencies_ignores = "['Products.CMFPlone', 'PIL']"

--- a/.meta.toml
+++ b/.meta.toml
@@ -7,4 +7,4 @@ commit-id = "cfffba8c"
 
 [pyproject]
 codespell_ignores = "complet,exemple"
-dependencies_ignores = "['Products.CMFPlone', 'PIL']"
+dependencies_ignores = "['Products.CMFPlone']"

--- a/news/122.bugfix
+++ b/news/122.bugfix
@@ -1,0 +1,4 @@
+Fix #122 validating if image is supported by PIL showing a validation error if not.
+Include Pillow dependency in setup.py.
+Fix ValueError: User could not be found in BaseTest setUp adding a transaction.commit().
+[rber474]

--- a/plone/app/users/tests/base.py
+++ b/plone/app/users/tests/base.py
@@ -24,6 +24,7 @@ from transaction import commit
 from zope.component import getSiteManager
 from zope.component import getUtility
 
+import transaction
 import unittest
 
 
@@ -42,6 +43,7 @@ class BaseTestCase(unittest.TestCase):
 
         self.browser = Browser(self.layer["app"])
         self.request = self.layer["request"]
+        transaction.commit()
 
     def tearDown(self):
         login(self.portal, "admin")

--- a/plone/app/users/tests/test_portrait.py
+++ b/plone/app/users/tests/test_portrait.py
@@ -1,0 +1,45 @@
+from pkg_resources import resource_stream
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.users.tests.base import BaseTestCase
+
+
+class TestPortrait(BaseTestCase):
+    def test_regression_supported_image_type_122(self):
+        # https://github.com/plone/plone.app.users/issues/122
+
+        self.browser.open("http://nohost/plone/")
+        self.browser.getLink("Log in").click()
+        self.browser.getControl("Login Name").value = SITE_OWNER_NAME
+        self.browser.getControl("Password").value = SITE_OWNER_PASSWORD
+        self.browser.getControl("Log in").click()
+        self.browser.open("http://nohost/plone/@@personal-information")
+        self.browser.getControl(name="form.widgets.email").value = "test@test.com"
+        portrait_file = resource_stream("plone.app.users.tests", "onepixel.jpg")
+        self.browser.getControl(name="form.widgets.portrait").add_file(
+            portrait_file, "image/jpg", "onepixel.# jpg"
+        )
+        self.browser.getControl("Save").click()
+        self.assertIn("Changes saved.", self.browser.contents)
+
+    def test_not_supported_image_type_122(self):
+        # https://github.com/plone/plone.app.users/issues/122
+
+        self.browser.open("http://nohost/plone/")
+        self.browser.getLink("Log in").click()
+        self.browser.getControl("Login Name").value = SITE_OWNER_NAME
+        self.browser.getControl("Password").value = SITE_OWNER_PASSWORD
+        self.browser.getControl("Log in").click()
+        self.browser.open("http://nohost/plone/@@personal-information")
+        self.browser.getControl(name="form.widgets.email").value = "test@test.com"
+        portrait_file = resource_stream(
+            "plone.app.users.tests", "transparent_square.svg"
+        )
+        self.browser.getControl(name="form.widgets.portrait").add_file(
+            portrait_file, "image/svg+xml", "onepixel.# jpg"
+        )
+        self.browser.getControl("Save").click()
+        self.assertIn(
+            "The file you selected is not supported by Pillow. Please choose another.",
+            self.browser.contents,
+        )

--- a/plone/app/users/tests/transparent_square.svg
+++ b/plone/app/users/tests/transparent_square.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="12" height="12">
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ Zope = [
 ]
 python-dateutil = ['dateutil']
 ignore-packages = ['Products.CMFPlone']
+Pillow = ['PIL']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     extras_require=extras_require,
     install_requires=[
         "Acquisition",
+        "Pillow",
         "Products.GenericSetup",
         "Products.PlonePAS >= 5.0.1",
         "Products.statusmessages",


### PR DESCRIPTION
Added a validation in the @@personal-information form for the portrait field.
If image is not supported by pillow an validation error will be shown.

@erral I haven't added any translations to plone.app.locales because I am not sure what the workflow is.

Running test I was getting an error for the tearDown so added a transaction.commit to setUp in BaseTest.

Please, review it and let me know if I wrong.