### PR TITLE
Fix view @@member-fields is public

### DIFF
--- a/news/125.bugfix
+++ b/news/125.bugfix
@@ -1,1 +1,1 @@
-[yurj] fix for https://github.com/plone/plone.app.users/issues/125 (view @@member-fields is public)
+Check plone.app.controlpanel.UsersAndGroups permission for the @@member-fields edit view. @yurj 

--- a/news/125.bugfix
+++ b/news/125.bugfix
@@ -1,0 +1,1 @@
+[yurj] fix for https://github.com/plone/plone.app.users/issues/125 (view @@member-fields is public)

--- a/news/125.bugfix
+++ b/news/125.bugfix
@@ -1,1 +1,1 @@
-Check plone.app.controlpanel.UsersAndGroups permission for the @@member-fields edit view. @yurj 
+Check `plone.app.controlpanel.UsersAndGroups` permission for the `@@member-fields` edit view. @yurj 

--- a/plone/app/users/browser/configure.zcml
+++ b/plone/app/users/browser/configure.zcml
@@ -80,7 +80,7 @@
       name="edit"
       for=".schemaeditor.IMemberSchemaContext"
       class=".schemaeditor.SchemaListingPage"
-      permission="zope2.View"
+      permission="plone.app.controlpanel.UsersAndGroups"
       />
 
   <browser:page


### PR DESCRIPTION
Protect `@@member-fields` additional traversal to the edit view of the schema context with the `plone.app.controlpanel.UsersAndGroups` permission, as the  `@@member-fields` view itself.
See https://community.plone.org/t/member-fields-browser-view-unprotected/20103
Issue: https://github.com/plone/plone.app.users/issues/125