### PR TITLE
missing string for locales

### DIFF
--- a/news/132.bugfix
+++ b/news/132.bugfix
@@ -1,0 +1,1 @@
+Add missing locale for translations [erral]

--- a/plone/app/users/schema.py
+++ b/plone/app/users/schema.py
@@ -79,7 +79,7 @@ class IUserDataSchema(Interface):
 
     email = ProtectedEmail(
         title=_("label_email", default="Email"),
-        description="We will use this address if you need to recover your " "password",
+        description=_("We will use this address if you need to recover your password"),
         required=True,
         constraint=checkEmailAddress,
     )


### PR DESCRIPTION
I keep the existing string without adding a label like in the other fields because we already have such string in plone.app.locales as a "manual" string: https://github.com/collective/plone.app.locales/blob/master/plone/app/locales/locales/plone-manual.pot#L225-L227

So it will be already translated in several languages and this way we will not create any new fuzzy strings.