### PR TITLE
Email validation: use method principal_id_or_login_name_exists if available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,24 @@ Changelog
 
 .. towncrier release notes start
 
+3.1.0 (2025-02-21)
+------------------
+
+New features:
+
+
+- Email validation: use new registration tool method `principal_id_or_login_name_exists` if available.
+  This helps in some corner cases when email-as-login is used.
+  [maurits] (#4120)
+
+
+Internal:
+
+
+- Update configuration files.
+  [plone devs]
+
+
 3.0.10 (2025-01-23)
 -------------------
 

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,2 +1,0 @@
-Update configuration files.
-[plone devs]

--- a/news/4120.feature
+++ b/news/4120.feature
@@ -1,3 +1,0 @@
-Email validation: use new registration tool method `principal_id_or_login_name_exists` if available.
-This helps in some corner cases when email-as-login is used.
-[maurits]

--- a/news/4120.feature
+++ b/news/4120.feature
@@ -1,0 +1,3 @@
+Email validation: use new registration tool method `principal_id_or_login_name_exists` if available.
+This helps in some corner cases when email-as-login is used.
+[maurits]

--- a/plone/app/users/tests/email_login.rst
+++ b/plone/app/users/tests/email_login.rst
@@ -133,3 +133,27 @@ We can really get the new user.
     >>> browser.getLink(url='bob-jones-1').click()
     >>> '@@user-information?userid=bob-jones-1' in browser.url
     True
+
+Saving this form without changes should work, without complaint that this login name is already taken.
+
+    >>> browser.getControl('Save').click()
+    >>> browser.contents
+    '...Changes saved...'
+
+Pick a different email address.
+
+    >>> browser.getControl('Email').value = "different@example.com"
+    >>> browser.getControl('Save').click()
+    >>> browser.contents
+    '...Changes saved...'
+
+Pick a valid email address with a format that may cause problems.
+This needs plone.schema 2.0.2, with a better email validation.
+This also needs a Products.CMFPlone release where the RegistrationTool has the principal_id_or_login_name_exists method.
+This is expected in 6.0.15, 6.1.1, and 6.2.0a1.
+TODO: enable this test after we have those releases.
+
+    .. >>> browser.getControl('Email').value = "o'hara@example.com"
+    .. >>> browser.getControl('Save').click()
+    .. >>> browser.contents
+    .. '...Changes saved...'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "3.1.0"
+version = "3.1.1.dev0"
 
 long_description = (
     f"{Path('README.rst').read_text()}\n{Path('CHANGES.rst').read_text()}"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "3.0.11.dev0"
+version = "3.1.0.dev0"
 
 long_description = (
     f"{Path('README.rst').read_text()}\n{Path('CHANGES.rst').read_text()}"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "3.1.0.dev0"
+version = "3.1.0"
 
 long_description = (
     f"{Path('README.rst').read_text()}\n{Path('CHANGES.rst').read_text()}"


### PR DESCRIPTION
This is a new method on the registration tool.  See open PR for CMFPlone 6.0.x: https://github.com/plone/Products.CMFPlone/pull/4120
When approved, I intend to forward port that to CMFPlone 6.1.x and master.

This avoids a problem with the `isMemberIdAllowed` method that we called until now: some valid emails are not valid as user id, for example an email address with a quote, and this makes the check fail.

The code should continue to work as before when this method does not exist.

Adding a test would be nice, but I expect this is too tricky in here.  I will have a try in the CMFPlone PR.