### PR TITLE
Remove superfluous comma on registration form.

### DIFF
--- a/news/139.bugfix
+++ b/news/139.bugfix
@@ -1,2 +1,3 @@
 Remove superfluous comma on registration form.
+Replace "e.g." with "for example".
 [maurits]

--- a/news/139.bugfix
+++ b/news/139.bugfix
@@ -1,0 +1,2 @@
+Remove superfluous comma on registration form.
+[maurits]

--- a/plone/app/users/browser/account.py
+++ b/plone/app/users/browser/account.py
@@ -35,7 +35,7 @@ from ZTUtils import make_query
 
 MESSAGE_EMAIL_CANNOT_CHANGE = _(
     "message_email_cannot_change",
-    default=("Sorry, you are not allowed to " "change your email address."),
+    default=("Sorry, you are not allowed to change your email address."),
 )
 
 MESSAGE_EMAIL_IN_USE = _(
@@ -49,7 +49,7 @@ MESSAGE_EMAIL_IN_USE = _(
 
 MESSAGE_IMAGE_NOT_SUPPORTED = _(
     "message_image_not_supported",
-    "The file you selected is not supported by Pillow. " "Please choose another.",
+    "The file you selected is not supported by Pillow. Please choose another.",
 )
 
 

--- a/plone/app/users/browser/passwordpanel.py
+++ b/plone/app/users/browser/passwordpanel.py
@@ -27,7 +27,7 @@ class IPasswordSchema(Interface):
         title=_("label_confirm_password", default="Confirm password"),
         description=_(
             "help_confirm_password",
-            default="Re-enter the password. " "Make sure the passwords are identical.",
+            default="Re-enter the password. Make sure the passwords are identical.",
         ),
     )
 

--- a/plone/app/users/browser/register.py
+++ b/plone/app/users/browser/register.py
@@ -341,7 +341,7 @@ class BaseRegistrationForm(AutoExtensibleForm, form.Form):
             # user id may not be the same as the portal id.
             if user_id == portal.getId():
                 err_str = _(
-                    "This username is reserved. Please choose a " "different name."
+                    "This username is reserved. Please choose a different name."
                 )
                 notifyWidgetActionExecutionError(action, username_field, err_str)
 
@@ -371,7 +371,7 @@ class BaseRegistrationForm(AutoExtensibleForm, form.Form):
             if not (data["password"] or data["mail_me"]):
                 err_str = _(
                     "msg_no_password_no_mail_me",
-                    default="You must set a password or choose to " "send an email.",
+                    default="You must set a password or choose to send an email.",
                 )
 
                 # set error on password field

--- a/plone/app/users/browser/register.py
+++ b/plone/app/users/browser/register.py
@@ -92,7 +92,7 @@ class BaseRegistrationForm(AutoExtensibleForm, form.Form):
                 "help_email_creation_for_login",
                 default="Enter an email "
                 "address. This will be your login name. We respect your "
-                "privacy, and will not give the address away to any third "
+                "privacy and will not give the address away to any third "
                 "parties or expose it anywhere.",
             )
             del self.fields["username"]
@@ -100,7 +100,7 @@ class BaseRegistrationForm(AutoExtensibleForm, form.Form):
             self.fields["email"].field.description = _(
                 "help_email_creation",
                 default="Enter an email address. This is necessary in case "
-                "the password is lost. We respect your privacy, and "
+                "the password is lost. We respect your privacy and "
                 "will not give the address away to any third parties "
                 "or expose it anywhere.",
             )

--- a/plone/app/users/browser/schemaeditor.py
+++ b/plone/app/users/browser/schemaeditor.py
@@ -205,7 +205,7 @@ class UsersMetadataSchemaExporter:
                 fieldNode.set(ns(attr, self.ns), v)
 
     def load(self, value):
-        listre = re.compile("(?P<type>list|set|tuple)" ":(?P<list>.*)", re_flags)
+        listre = re.compile("(?P<type>list|set|tuple):(?P<list>.*)", re_flags)
         ltypes = {
             "list": list,
             "set": set,

--- a/plone/app/users/schema.py
+++ b/plone/app/users/schema.py
@@ -107,14 +107,14 @@ class IRegisterSchema(Interface):
         title=_("label_confirm_password", default="Confirm password"),
         description=_(
             "help_confirm_password",
-            default="Re-enter the password. " "Make sure the passwords are identical.",
+            default="Re-enter the password. Make sure the passwords are identical.",
         ),
     )
 
     mail_me = schema.Bool(
         title=_(
             "label_mail_password",
-            default="Send a confirmation mail with a link to set the " "password",
+            default="Send a confirmation mail with a link to set the password",
         ),
         required=False,
         default=False,

--- a/plone/app/users/schema.py
+++ b/plone/app/users/schema.py
@@ -72,7 +72,8 @@ class IUserDataSchema(Interface):
     fullname = ProtectedTextLine(
         title=_("label_full_name", default="Full Name"),
         description=_(
-            "help_full_name_creation", default="Enter full name, e.g. John Smith."
+            "help_full_name_creation",
+            default="Enter full name, for example, John Smith.",
         ),
         required=False,
     )

--- a/plone/app/users/upgrades.py
+++ b/plone/app/users/upgrades.py
@@ -36,7 +36,7 @@ class IHomePageSchema(Interface):
         title=_("label_homepage", default="Home page"),
         description=_(
             "help_homepage",
-            default="The URL for your external home page, " "if you have one.",
+            default="The URL for your external home page, if you have one.",
         ),
         required=False,
     )


### PR DESCRIPTION
@stevepiercy I have a British client who wants to remove a comma on the registration or new user form.  Example in Classic UI if you login as Manager and add a new user, and look at the help text of the Email field:

https://classic.demo.plone.org/@@new-user

Would you agree with this change?  I have no opinion here. :-)

For the client I just add a custom `en/LC_MESSAGES/plone.po` file in their policy package, where I remove the comma, so its solved for them.